### PR TITLE
Fix typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install via CDN
 Register VueResizeText globally:
 
 ```javascript
-import Vue from 'Vue';
+import Vue from 'vue';
 import VueResizeText from 'vue-resize-text';
 
 Vue.use(VueResizeText)


### PR DESCRIPTION
Thank you for this awesome work.

Just trying to follow the documentation by `copying & paste` and got an error.

```sh
This dependency was not found:

* Vue in ./src/plugins/vue-resize-text.js

To install it, you can run: npm install --save Vue
```

I think it must import from 'vue' (lowercase).